### PR TITLE
build: plugin to 6.3.3, standardized project names, validation module

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.session-examples.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.session-examples.gradle
@@ -4,7 +4,10 @@ plugins {
 }
 
 dependencies {
-    testImplementation(projects.session)
+    testAnnotationProcessor(mnValidation.micronaut.validation.processor)
+    testImplementation(mnValidation.micronaut.validation)
+
+    testImplementation(projects.micronautSession)
 
     testImplementation mn.reactor
     testImplementation(mn.micronaut.http.client)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,9 @@ micronaut-cache = "4.0.0-SNAPSHOT"
 micronaut-docs = "2.0.0"
 micronaut-serde = "2.0.0-SNAPSHOT"
 micronaut-test = "4.0.0-SNAPSHOT"
+micronaut-validation = "4.0.0-SNAPSHOT"
 
-groovy = "4.0.6"
+groovy = "4.0.9"
 junit = '5.9.2'
 kotest = '5.5.5'
 kotlin = '1.8.10'
@@ -14,6 +15,7 @@ spock = "2.3-groovy-4.0"
 [libraries]
 micronaut-cache = { module = "io.micronaut.cache:micronaut-cache-bom", version.ref = "micronaut-cache" }
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
+micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api', version.ref = 'junit' }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine', version.ref = 'junit' }

--- a/session/build.gradle
+++ b/session/build.gradle
@@ -3,6 +3,9 @@ plugins {
 }
 
 dependencies {
+    annotationProcessor(mnValidation.micronaut.validation.processor)
+    implementation(mnValidation.micronaut.validation)
+
     api(mn.micronaut.http)
 
     implementation(mnCache.micronaut.cache.caffeine)

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.3.1'
+    id 'io.micronaut.build.shared.settings' version '6.3.3'
 }
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
@@ -23,8 +23,10 @@ include 'docs-examples:example-java'
 include 'docs-examples:example-kotlin'
 
 micronautBuild {
+    useStandardizedProjectNames = true
     addSnapshotRepository()
     importMicronautCatalog()
     importMicronautCatalog("micronaut-cache")
     importMicronautCatalog("micronaut-serde")
+    importMicronautCatalog("micronaut-validation")
 }

--- a/test-suite-graal/build.gradle
+++ b/test-suite-graal/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api(mn.micronaut.http)
 
     testAnnotationProcessor(mn.micronaut.inject.java)
-    testImplementation(project(":session"))
+    testImplementation(projects.micronautSession)
     testImplementation(mn.reactor)
     testImplementation(mn.micronaut.graal)
     testImplementation(mn.micronaut.http.client)


### PR DESCRIPTION
closes #35 

This adds the `micronaut-validation` module because it has to for a successful build. However once #34 is merged, it should be removed again.  🐥 🥚