### PR TITLE
Fix session event listener registration

### DIFF
--- a/session/src/main/java/io/micronaut/session/InMemorySessionStore.java
+++ b/session/src/main/java/io/micronaut/session/InMemorySessionStore.java
@@ -23,13 +23,12 @@ import com.github.benmanes.caffeine.cache.Scheduler;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.annotation.Internal;
-import org.jspecify.annotations.NonNull;
-import io.micronaut.session.event.AbstractSessionEvent;
 import io.micronaut.session.event.SessionCreatedEvent;
 import io.micronaut.session.event.SessionDeletedEvent;
 import io.micronaut.session.event.SessionDestroyedEvent;
 import io.micronaut.session.event.SessionExpiredEvent;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.NonNull;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -46,7 +45,11 @@ import java.util.concurrent.CompletableFuture;
 public class InMemorySessionStore implements SessionStore<InMemorySession> {
 
     private final SessionConfiguration sessionConfiguration;
-    private final ApplicationEventPublisher<? super AbstractSessionEvent> eventPublisher;
+    private final ApplicationEventPublisher<SessionCreatedEvent> sessionCreatedEventPublisher;
+    private final ApplicationEventPublisher<SessionDeletedEvent> sessionDeletedEventPublisher;
+    private final ApplicationEventPublisher<SessionExpiredEvent> sessionExpiredEventPublisher;
+    private final ApplicationEventPublisher<SessionDestroyedEvent> sessionDestroyedEventPublisher;
+
     private final Cache<String, InMemorySession> sessions;
     private final SessionIdGenerator sessionIdGenerator;
 
@@ -55,15 +58,24 @@ public class InMemorySessionStore implements SessionStore<InMemorySession> {
      *
      * @param sessionIdGenerator The session id generator
      * @param sessionConfiguration The sessions configuration
-     * @param eventPublisher The application event publisher
+     * @param sessionCreatedEventPublisher The session created event publisher
+     * @param sessionDeletedEventPublisher The session deleted event publisher
+     * @param sessionExpiredEventPublisher The session expired event publisher
+     * @param sessionDestroyedEventPublisher The session destroyed event publisher
      */
     public InMemorySessionStore(
         SessionIdGenerator sessionIdGenerator,
         SessionConfiguration sessionConfiguration,
-        ApplicationEventPublisher<? super AbstractSessionEvent> eventPublisher) {
+        ApplicationEventPublisher<SessionCreatedEvent> sessionCreatedEventPublisher,
+        ApplicationEventPublisher<SessionDeletedEvent> sessionDeletedEventPublisher,
+        ApplicationEventPublisher<SessionExpiredEvent> sessionExpiredEventPublisher,
+        ApplicationEventPublisher<SessionDestroyedEvent> sessionDestroyedEventPublisher) {
 
         this.sessionIdGenerator = sessionIdGenerator;
-        this.eventPublisher = eventPublisher;
+        this.sessionCreatedEventPublisher = sessionCreatedEventPublisher;
+        this.sessionDeletedEventPublisher = sessionDeletedEventPublisher;
+        this.sessionExpiredEventPublisher = sessionExpiredEventPublisher;
+        this.sessionDestroyedEventPublisher = sessionDestroyedEventPublisher;
         this.sessionConfiguration = sessionConfiguration;
         this.sessions = newSessionCache(sessionConfiguration);
     }
@@ -100,7 +112,7 @@ public class InMemorySessionStore implements SessionStore<InMemorySession> {
         if (session != existing) {
             sessions.put(id, session);
             if (existing == null) {
-                eventPublisher.publishEvent(new SessionCreatedEvent(session));
+                sessionCreatedEventPublisher.publishEvent(new SessionCreatedEvent(session));
             }
         }
         return CompletableFuture.completedFuture(session);
@@ -163,9 +175,9 @@ public class InMemorySessionStore implements SessionStore<InMemorySession> {
     private RemovalListener<String, Session> newRemovalListener() {
         return (key, value, cause) -> {
             switch (cause) {
-                case REPLACED -> eventPublisher.publishEvent(new SessionDestroyedEvent(value));
-                case SIZE, EXPIRED -> eventPublisher.publishEvent(new SessionExpiredEvent(value));
-                case EXPLICIT -> eventPublisher.publishEvent(new SessionDeletedEvent(value));
+                case REPLACED -> sessionDestroyedEventPublisher.publishEvent(new SessionDestroyedEvent(value));
+                case SIZE, EXPIRED -> sessionExpiredEventPublisher.publishEvent(new SessionExpiredEvent(value));
+                case EXPLICIT -> sessionDeletedEventPublisher.publishEvent(new SessionDeletedEvent(value));
                 default ->
                     throw new IllegalStateException("Session should never be garbage collectable");
             }

--- a/session/src/test/java/io/micronaut/session/SessionEventListenerRegistrationTest.java
+++ b/session/src/test/java/io/micronaut/session/SessionEventListenerRegistrationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.session;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.runtime.event.annotation.EventListener;
+import io.micronaut.session.event.SessionCreatedEvent;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SessionEventListenerRegistrationTest {
+
+    @Test
+    void concreteSessionListenersReceivePublishedEvents() throws Exception {
+        try (ApplicationContext applicationContext = ApplicationContext.run()) {
+            InMemorySessionStore sessionStore = applicationContext.getBean(InMemorySessionStore.class);
+            ConcreteCreatedListener concreteCreatedListener = applicationContext.getBean(ConcreteCreatedListener.class);
+            AnnotatedSessionListener annotatedSessionListener = applicationContext.getBean(AnnotatedSessionListener.class);
+            InMemorySession session = sessionStore.newSession();
+
+            session.put("foo", "bar");
+            sessionStore.save(session).get();
+
+            assertEquals(List.of(session.getId()), concreteCreatedListener.eventIds());
+            assertEquals(List.of(session.getId()), annotatedSessionListener.eventIds());
+        }
+    }
+
+    @Singleton
+    static final class ConcreteCreatedListener implements ApplicationEventListener<SessionCreatedEvent> {
+        private final List<String> eventIds = new ArrayList<>();
+
+        @Override
+        public void onApplicationEvent(SessionCreatedEvent event) {
+            eventIds.add(event.getSource().getId());
+        }
+
+        List<String> eventIds() {
+            return eventIds;
+        }
+    }
+
+    @Singleton
+    static final class AnnotatedSessionListener {
+        private final List<String> eventIds = new ArrayList<>();
+
+        @EventListener
+        void onSessionCreated(SessionCreatedEvent event) {
+            eventIds.add(event.getSource().getId());
+        }
+
+        List<String> eventIds() {
+            return eventIds;
+        }
+    }
+}


### PR DESCRIPTION
This pull-request replaces: 

```java
 private final ApplicationEventPublisher<? super AbstractSessionEvent> eventPublisher;
```

with:

```java
    private final ApplicationEventPublisher<SessionCreatedEvent> sessionCreatedEventPublisher;
    private final ApplicationEventPublisher<SessionDeletedEvent> sessionDeletedEventPublisher;
    private final ApplicationEventPublisher<SessionExpiredEvent> sessionExpiredEventPublisher;
    private final ApplicationEventPublisher<SessionDestroyedEvent> sessionDestroyedEventPublisher;
```

## Summary
- publish session lifecycle events through concrete typed publishers so exact listeners are resolved
- add a regression test covering both ApplicationEventListener<SessionCreatedEvent> and @EventListener listeners

## Verification
- ./gradlew :micronaut-session:test --tests 'io.micronaut.session.SessionEventListenerRegistrationTest'
- ./gradlew :micronaut-session:test --tests 'io.micronaut.session.SessionEventListenerRegistrationTest' --tests 'io.micronaut.session.InMemorySessionStoreSpec'

Resolves #251

using `ApplicationEventPublisher<? super AbstractSessionEvent> ` des not work. 

Update project. Replace the usage of TestRestTemplate with a newer client-based test setup across the Boot tests.


>  Because in this case ? super AbstractSessionEvent only helps the Java compiler. It does not make Micronaut treat the publisher as “dispatch to all subclasses of AbstractSessionEvent”.
> 
>   What Micronaut actually does is:
> 
>   - At injection time, it looks at the publisher injection point’s type argument.
>   - For ApplicationEventPublisher<? super AbstractSessionEvent>, that effectively resolves to AbstractSessionEvent.
>   - It then builds a typed publisher for that one event type.
>   - That typed publisher caches listeners by type argument AbstractSessionEvent, not by the runtime subtype being published.
> 
>   So with the old field in session/src/main/java/io/micronaut/session/InMemorySessionStore.java:48, Micronaut was effectively doing:
> 
>   - “give me listeners of ApplicationEventListener<AbstractSessionEvent>”
> 
>   That includes the existing Groovy listener in InMemorySessionStoreSpec, but it does not include:
> 
>   - ApplicationEventListener<SessionCreatedEvent>
>   - @EventListener methods for SessionCreatedEvent
> 
>   Those are registered for the concrete subtype, so they were never selected.
> 
>   Why ApplicationEventPublisher<Object> works:
> 
>   - Micronaut has a special Object publisher path.
>   - That path re-resolves the publisher by the actual runtime event class, e.g. SessionCreatedEvent.
>   - Then it finds listeners for that concrete event type, so both subtype listeners and @EventListener methods are invoked.
> 
>   Short version: ? super AbstractSessionEvent is contravariant at compile time, but Micronaut’s publisher lookup is keyed by the resolved generic type, and that lookup is not contravariant.                                                                                                                                         
>   Let me look at whether this workaround is worth implementing in micronaut-security:    