### PR TITLE
fix: apply HttpSessionFilter under custom context path

### DIFF
--- a/session/src/main/java/io/micronaut/session/http/HttpSessionFilter.java
+++ b/session/src/main/java/io/micronaut/session/http/HttpSessionFilter.java
@@ -34,6 +34,7 @@ import io.micronaut.session.SessionStore;
 import io.micronaut.session.annotation.SessionValue;
 import io.micronaut.web.router.MethodBasedRouteInfo;
 import io.micronaut.web.router.RouteInfo;
+import jakarta.inject.Inject;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
@@ -73,8 +74,22 @@ public class HttpSessionFilter implements Ordered {
      * @param sessionStore The session store
      * @param resolvers The HTTP session id resolvers
      * @param encoders The HTTP session id encoders
+     */
+    public HttpSessionFilter(SessionStore<Session> sessionStore,
+                             HttpSessionIdResolver[] resolvers,
+                             HttpSessionIdEncoder[] encoders) {
+        this(sessionStore, resolvers, encoders, new HttpSessionFilterConfigurationProperties());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param sessionStore The session store
+     * @param resolvers The HTTP session id resolvers
+     * @param encoders The HTTP session id encoders
      * @param configuration The filter configuration
      */
+    @Inject
     public HttpSessionFilter(SessionStore<Session> sessionStore,
                              HttpSessionIdResolver[] resolvers,
                              HttpSessionIdEncoder[] encoders,

--- a/session/src/main/java/io/micronaut/session/http/HttpSessionFilter.java
+++ b/session/src/main/java/io/micronaut/session/http/HttpSessionFilter.java
@@ -26,7 +26,6 @@ import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.http.exceptions.HttpStatusException;
-import io.micronaut.http.filter.FilterPatternStyle;
 import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.http.server.exceptions.InternalServerException;
 import io.micronaut.inject.MethodExecutionHandle;
@@ -41,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.regex.Pattern;
 
 /**
  * A server filter that resolves the current user {@link Session} if present and encodes the Session ID in
@@ -50,8 +50,7 @@ import java.util.concurrent.CompletionStage;
  * @since 1.0
  */
 @Requires(property = HttpSessionFilterConfigurationProperties.PROPERTY_ENABLED, notEquals = StringUtils.FALSE, defaultValue = StringUtils.TRUE)
-@ServerFilter(patternStyle = FilterPatternStyle.REGEX,
-    value = "${" + HttpSessionFilterConfigurationProperties.PROPERTY_REGEX_PATTERN + ":" + HttpSessionFilterConfigurationProperties.DEFAULT_REGEX_PATTERN + "}")
+@ServerFilter("/**")
 public class HttpSessionFilter implements Ordered {
     /**
      * The order of the filter.
@@ -66,6 +65,7 @@ public class HttpSessionFilter implements Ordered {
     private final SessionStore<Session> sessionStore;
     private final HttpSessionIdResolver[] resolvers;
     private final HttpSessionIdEncoder[] encoders;
+    private final @Nullable Pattern regexPattern;
 
     /**
      * Constructor.
@@ -73,11 +73,18 @@ public class HttpSessionFilter implements Ordered {
      * @param sessionStore The session store
      * @param resolvers The HTTP session id resolvers
      * @param encoders The HTTP session id encoders
+     * @param configuration The filter configuration
      */
-    public HttpSessionFilter(SessionStore<Session> sessionStore, HttpSessionIdResolver[] resolvers, HttpSessionIdEncoder[] encoders) {
+    public HttpSessionFilter(SessionStore<Session> sessionStore,
+                             HttpSessionIdResolver[] resolvers,
+                             HttpSessionIdEncoder[] encoders,
+                             HttpSessionFilterConfiguration configuration) {
         this.sessionStore = sessionStore;
         this.resolvers = resolvers;
         this.encoders = encoders;
+        this.regexPattern = HttpSessionFilterConfigurationProperties.DEFAULT_REGEX_PATTERN.equals(configuration.getRegexPattern())
+            ? null
+            : Pattern.compile(configuration.getRegexPattern());
     }
 
     @Override
@@ -93,6 +100,9 @@ public class HttpSessionFilter implements Ordered {
      */
     @RequestFilter
     public CompletionStage<HttpRequest<?>> filterRequest(HttpRequest<?> request) {
+        if (!matchesFilter(request)) {
+            return CompletableFuture.completedFuture(request);
+        }
         return loadSessionIntoRequest(request);
     }
 
@@ -108,10 +118,21 @@ public class HttpSessionFilter implements Ordered {
     public CompletionStage<MutableHttpResponse<?>> filterResponse(HttpRequest<?> request,
                                                                   MutableHttpResponse<?> response,
                                                                   @Nullable RouteInfo<?> routeInfo) {
+        if (!isFilterApplied(request)) {
+            return CompletableFuture.completedFuture(response);
+        }
         MethodExecutionHandle<?, ?> routeMatch = routeInfo instanceof MethodBasedRouteInfo<?, ?> methodBasedRouteInfo
             ? methodBasedRouteInfo.getTargetMethod()
             : null;
         return encodeSessionInResponse(request, response, routeMatch);
+    }
+
+    private boolean matchesFilter(HttpRequest<?> request) {
+        return regexPattern == null || regexPattern.matcher(request.getPath()).matches();
+    }
+
+    private boolean isFilterApplied(HttpRequest<?> request) {
+        return request.getAttribute(HttpSessionFilter.class.getName(), Boolean.class).orElse(false);
     }
 
     private CompletionStage<HttpRequest<?>> loadSessionIntoRequest(HttpRequest<?> request) {

--- a/session/src/test/java/io/micronaut/session/HttpSessionFilterApiTest.java
+++ b/session/src/test/java/io/micronaut/session/HttpSessionFilterApiTest.java
@@ -1,13 +1,20 @@
 package io.micronaut.session;
 
 import io.micronaut.core.order.Ordered;
+import io.micronaut.http.HttpRequest;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterPhase;
+import io.micronaut.session.http.HttpSessionIdEncoder;
+import io.micronaut.session.http.HttpSessionIdResolver;
 import io.micronaut.session.http.HttpSessionFilter;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HttpSessionFilterApiTest {
@@ -17,5 +24,39 @@ class HttpSessionFilterApiTest {
         assertFalse(HttpServerFilter.class.isAssignableFrom(HttpSessionFilter.class));
         assertTrue(Ordered.class.isAssignableFrom(HttpSessionFilter.class));
         assertEquals(ServerFilterPhase.SESSION.order(), HttpSessionFilter.ORDER);
+    }
+
+    @Test
+    void httpSessionFilterRetainsLegacyThreeArgumentConstructor() {
+        HttpSessionFilter filter = new HttpSessionFilter(
+            new NoOpSessionStore(),
+            new HttpSessionIdResolver[0],
+            new HttpSessionIdEncoder[0]
+        );
+
+        assertNotNull(filter);
+        assertNotNull(filter.filterRequest(HttpRequest.GET("/demo")));
+    }
+
+    private static final class NoOpSessionStore implements SessionStore<Session> {
+        @Override
+        public Session newSession() {
+            throw new UnsupportedOperationException("Not needed for constructor compatibility coverage");
+        }
+
+        @Override
+        public CompletableFuture<Optional<Session>> findSession(String id) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        @Override
+        public CompletableFuture<Boolean> deleteSession(String id) {
+            return CompletableFuture.completedFuture(Boolean.FALSE);
+        }
+
+        @Override
+        public CompletableFuture<Session> save(Session session) {
+            return CompletableFuture.completedFuture(session);
+        }
     }
 }

--- a/session/src/test/java/io/micronaut/session/HttpSessionFilterContextPathTest.java
+++ b/session/src/test/java/io/micronaut/session/HttpSessionFilterContextPathTest.java
@@ -1,0 +1,51 @@
+package io.micronaut.session;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.session.Session;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Property(name = "micronaut.server.context-path", value = "/foo")
+@Property(name = "micronaut.session.http.cookie", value = "true")
+@Property(name = "micronaut.session.http.cookie-path", value = "/foo")
+@Property(name = "spec.name", value = "HttpSessionFilterContextPathTest")
+@MicronautTest
+class HttpSessionFilterContextPathTest {
+
+    @Test
+    void testHttpSessionFilterAppliesToContextPathPrefixedRequests(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpResponse<String> response = assertDoesNotThrow(() -> client.exchange(HttpRequest.GET("/foo/demo"), String.class));
+
+        assertEquals(HttpStatus.OK, response.status());
+        assertEquals("ok", response.body());
+        assertNotNull(response.header(HttpHeaders.SET_COOKIE));
+        assertTrue(response.header(HttpHeaders.SET_COOKIE).contains("SESSION"));
+        assertTrue(response.header(HttpHeaders.SET_COOKIE).contains("Path=/foo"));
+    }
+
+    @Requires(property = "spec.name", value = "HttpSessionFilterContextPathTest")
+    @Controller("/demo")
+    static class DemoController {
+        @Get
+        String index(Session session) {
+            session.put("demo", "ok");
+            return "ok";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- restore catch-all `HttpSessionFilter` registration so requests under a custom `micronaut.server.context-path` still reach session processing
- preserve explicit `micronaut.session.filter.regex-pattern` behavior by enforcing non-default regexes inside the filter against `request.getPath()`
- add a regression test that proves `Session` binding and session-cookie emission for `GET /foo/demo` when `micronaut.server.context-path=/foo`

## Verification

- `./gradlew :micronaut-session:test --rerun-tasks --tests 'io.micronaut.session.HttpSessionFilterContextPathTest' --tests 'io.micronaut.session.HttpSessionFilterPatternTest' --tests 'io.micronaut.session.HttpSessionFilterDisabledTest'`
- `./gradlew :micronaut-session:test --rerun-tasks --tests 'io.micronaut.session.HttpSessionFilterConfigurationTest' --tests 'io.micronaut.session.HttpSessionFilterContextPathTest' --tests 'io.micronaut.session.HttpSessionFilterDisabledTest' --tests 'io.micronaut.session.HttpSessionFilterPatternTest' --tests 'io.micronaut.session.MalformedSessionCookieValueTest' --tests 'io.micronaut.session.SessionEventListenerRegistrationTest'`
- `./gradlew :micronaut-session:spotlessCheck`

Closes #285.

QA selected the Micronaut organization project `5.0.0 Release`; the preserved ambiguity note is that `5.0.0-M3` exists as a prerelease board, but `5.0.0 Release` remains the correct stable board for this default-branch bug fix.

This run could not apply the live organization-project link because the authenticated `gh` session lacks GitHub project scopes (`read:project` / `project`).

---
###### ✨ This message was AI-generated using gpt-5.4
